### PR TITLE
Fix Bug transanction_result approved? function

### DIFF
--- a/lib/webpay_rails/transaction_result.rb
+++ b/lib/webpay_rails/transaction_result.rb
@@ -19,7 +19,7 @@ module WebpayRails
     end
 
     def approved?
-      @response_code == 0
+      @response_code.to_i == 0
     end
   end
 end


### PR DESCRIPTION
In `parse.rb` everything is parse as an string and then there is a comparision of the `response_code` with an integer for the function `approved?`

``` ruby
WebpayRails::TransactionResult.new({
  [...]
  commerce_code: document.at_xpath('//commercecode').text.to_s,
  authorization_code: document.at_xpath('//authorizationcode').text.to_s,
  payment_type_code: document.at_xpath('//paymenttypecode').text.to_s,
  response_code: document.at_xpath('//responsecode').text.to_s,
  transaction_date: document.at_xpath('//transactiondate').text.to_s,
  [...]
})
```

``` ruby
def approved?
  @response_code.to_i == 0
end
```

BTW thanks for sharing the project
